### PR TITLE
Add possessive guards to prevent external lookup on internal context …

### DIFF
--- a/api/core/intelligence/truthTypeDetector.js
+++ b/api/core/intelligence/truthTypeDetector.js
@@ -405,7 +405,13 @@ export function detectByPattern(query) {
     /\brecent\b.{0,50}\b(announcements?|releases?|launches?)\b/i,
     /\b(announcements?|releases?|launches?).{0,30}\b(recent|latest|newest|new)\b/i,
   ];
-  const hasFreshnessMarker = FRESHNESS_OVERRIDE_PATTERNS.some(p => p.test(query));
+  let hasFreshnessMarker = FRESHNESS_OVERRIDE_PATTERNS.some(p => p.test(query));
+  if (hasFreshnessMarker && /\b(our|my)\b/i.test(query)) {
+    // Possessive + freshness marker = internal context query
+    // Do not treat as external lookup candidate
+    // Fall through to conversational/personal detection
+    hasFreshnessMarker = false;
+  }
   if (hasFreshnessMarker) {
     console.log(`[TRUTH-TYPE] Freshness marker detected — forcing SEMI_STABLE classification (external lookup required)`);
     return {

--- a/api/core/orchestrator.js
+++ b/api/core/orchestrator.js
@@ -1325,7 +1325,7 @@ export class Orchestrator {
               (isCurrentEventQuery(m.content) || isFactualEntityQuery(m.content))
             );
 
-        const shouldLookup =
+        let shouldLookup =
           truthTypeResult.type === 'VOLATILE' ||
           (truthTypeResult.type === 'SEMI_STABLE' && matchesNewsPattern) ||
           (truthTypeResult.type === 'SEMI_STABLE' && hasExplicitFreshnessMarker) ||
@@ -1334,6 +1334,13 @@ export class Orchestrator {
           isFactualEntityLookupQuery ||
           isSemanticCurrentEventQuery ||   // Issue #881: entity + action pattern
           isVolatileFollowUp;              // Issue #881: follow-up inherits volatile context
+
+        // Possessive guard: queries about "our"/"my" things refer to internal context,
+        // not external data. Override shouldLookup to prevent wasted external API calls.
+        const hasPersonalOrgContext = /\b(our|my)\b/i.test(message);
+        if (hasPersonalOrgContext) {
+          shouldLookup = false;
+        }
 
         // Debug logging for lookup decision
         console.log('[ORCHESTRATOR] Lookup decision:', {
@@ -1496,13 +1503,19 @@ export class Orchestrator {
             phase4Metadata.failure_reason = lookupResult.failure_reason || 'No reliable parseable source available for this query type';
             this.log(`⚠️ External lookup: ${phase4Metadata.failure_reason}`);
           } else {
-            // Lookup failed or returned no data
+            // Lookup returned no data — distinguish between "not required" (possessive gate)
+            // and genuine failure (error/timeout). Only mark as attempted if a real error occurred.
+            const wasGenuineFailure = !!lookupResult.error;
             phase4Metadata.external_lookup = false;
-            phase4Metadata.lookup_attempted = true;
+            phase4Metadata.lookup_attempted = wasGenuineFailure;
             phase4Metadata.fetched_content = null;
             phase4Metadata.sources_used = 0;
-            phase4Metadata.failure_reason = lookupResult.error || 'External lookup failed or returned no data';
-            this.log("⚠️ External lookup failed or returned no data");
+            if (wasGenuineFailure) {
+              phase4Metadata.failure_reason = lookupResult.error;
+              this.log("⚠️ External lookup failed or returned no data");
+            } else {
+              this.log("[PHASE4] Lookup not required by engine (possessive/internal query) — lookup_attempted stays false");
+            }
           }
           } // end else (refersToDocumentForLookup)
         }


### PR DESCRIPTION
…queries

- truthTypeDetector.js: When FRESHNESS_OVERRIDE_PATTERNS matches (e.g. "current status") but query contains "our"/"my", reset hasFreshnessMarker to false so the query falls through to conversational/personal detection instead of early-returning as SEMI_STABLE with explicit_freshness_marker.

- orchestrator.js: Add hasPersonalOrgContext guard after shouldLookup assignment — queries containing "our"/"my" override shouldLookup to false regardless of truth type or freshness markers.

- orchestrator.js: Fix else branch in lookup result handling — only set lookup_attempted=true when lookupResult.error exists (genuine failure). When lookup() returns success:true with lookup_performed:false (possessive gate blocked it), lookup_attempted stays false so the internal context injection branch fires correctly.

https://claude.ai/code/session_01WKViZvqjN9PyaDfMW1JVzp