### PR TITLE
Pass 11 mascot percentage-based panel-edge anchoring

### DIFF
--- a/public/css/overhaul.css
+++ b/public/css/overhaul.css
@@ -2455,3 +2455,58 @@ header {
     display: none !important;
   }
 }
+
+/* ============================================================
+   PASS 11 — Mascot percentage-based panel-edge anchoring
+   Appended after Pass 10. CSS-only; no JS/HTML changes.
+
+   Lock mascots to panel edges using percentage positioning
+   tied to .main-wrapper width, matching .main-content which
+   is 92% wide centered = 4% gutter each side.
+   Negative offset pulls them outside, positive pulls inside.
+   Target: mostly outside with slight overlap (ear/elbow/foot).
+
+   NOTE: the new transforms include translateY(-50%) to
+   preserve the vertical centering from the embedded
+   `.mascot { top: 50%; transform: translateY(-50%) }` rule.
+   ============================================================ */
+
+@media (min-width: 900px) {
+  .mascot-left {
+    left: 0% !important;
+    transform: translateX(-75%) translateY(-50%) !important;
+  }
+  .mascot-right {
+    right: 0% !important;
+    transform: translateX(75%) translateY(-50%) !important;
+  }
+}
+
+@media (min-width: 1522px) {
+  .mascot-left {
+    left: 0% !important;
+    transform: translateX(-75%) translateY(-50%) !important;
+  }
+  .mascot-right {
+    right: 0% !important;
+    transform: translateX(75%) translateY(-50%) !important;
+  }
+}
+
+/* Show mascots on landscape but small and tucked */
+@media (max-width: 950px) and (orientation: landscape) {
+  .mascot {
+    display: block !important;
+    height: calc(100vh - 140px) !important;
+    min-height: 220px !important;
+    max-height: 280px !important;
+  }
+  .mascot-left {
+    left: 0% !important;
+    transform: translateX(-75%) translateY(-50%) !important;
+  }
+  .mascot-right {
+    right: 0% !important;
+    transform: translateX(75%) translateY(-50%) !important;
+  }
+}


### PR DESCRIPTION
Lock mascots to panel edges via left/right: 0% +
transform translateX(-75%) / translateX(75%). The
translateY(-50%) is preserved in the transform to
keep vertical centering from the embedded rule.

- @media (min-width: 900px): left:0% / right:0% with translateX -75% / +75%
- @media (min-width: 1522px): same
- @media (max-width: 950px) and (orientation: landscape): reverts Pass 10's display:none and shows mascots small (220-280px tall) with the same translateX anchor

CSS-only. No JS, HTML, or structural changes.

https://claude.ai/code/session_017ji176hGykfVzFtAXwVPUj