### PR TITLE
Pass 12 simple vw-based mascot positioning

### DIFF
--- a/public/css/overhaul.css
+++ b/public/css/overhaul.css
@@ -2510,3 +2510,42 @@ header {
     transform: translateX(75%) translateY(-50%) !important;
   }
 }
+
+/* PASS 11 — Simple viewport-relative mascot positioning.
+   Removes all complex transform/calc approaches.
+   Uses simple vw-based offsets that scale with screen width. */
+
+@media (min-width: 900px) {
+  .mascot {
+    display: block !important;
+  }
+
+  .mascot-left {
+    left: -8vw !important;
+    transform: translateY(-50%) !important;
+  }
+
+  .mascot-right {
+    right: -8vw !important;
+    transform: translateY(-50%) !important;
+  }
+}
+
+@media (max-width: 950px) and (orientation: landscape) {
+  .mascot {
+    display: block !important;
+    height: calc(100vh - 140px) !important;
+    min-height: 200px !important;
+    max-height: 260px !important;
+  }
+
+  .mascot-left {
+    left: -6vw !important;
+    transform: translateY(-50%) !important;
+  }
+
+  .mascot-right {
+    right: -6vw !important;
+    transform: translateY(-50%) !important;
+  }
+}


### PR DESCRIPTION
Replaces the complex percentage + translateX anchoring from the prior pass with plain viewport-width offsets:

- @media (min-width: 900px): .mascot display:block, .mascot-left/-right at -8vw, transform kept as translateY(-50%) only
- @media (max-width: 950px) and (orientation: landscape): .mascot shown at 200-260px height, offsets at -6vw, transform kept as translateY(-50%) only

Note: the user's comment labels this "PASS 11" but it is appended after the previous pass that was also called "Pass 11" — tracking it internally as Pass 12 for commit history monotonicity. Later source order + !important ensures these rules win over all prior mascot positioning.

CSS-only. No JS, HTML, or structural changes.

https://claude.ai/code/session_017ji176hGykfVzFtAXwVPUj