### PR TITLE
Pass 13 content-with-mascots wrapper + landscape mobile fixes

### DIFF
--- a/public/css/overhaul.css
+++ b/public/css/overhaul.css
@@ -2549,3 +2549,87 @@ header {
     transform: translateY(-50%) !important;
   }
 }
+
+/* ============================================================
+   PASS 13 — content-with-mascots wrapper + rocket/mode fixes
+   Appended after Pass 12. CSS-only additions here; the HTML
+   restructure to introduce .content-with-mascots is in
+   index.html.
+   ============================================================ */
+
+/* -----------------------------------------------------------
+   FIX 1b — .content-with-mascots container
+   New positioning ancestor for the mascots. Same 92% width +
+   1400px max as .main-content so the mascots' absolute
+   positioning is relative to a box that exactly matches the
+   main-content card's outer edges.
+   ----------------------------------------------------------- */
+.content-with-mascots {
+  position: relative !important;
+  display: flex !important;
+  justify-content: center !important;
+  align-items: flex-start !important;
+  width: 92% !important;
+  max-width: 1400px !important;
+  margin: 0 auto !important;
+}
+
+/* -----------------------------------------------------------
+   FIX 1b — Mascot positioning relative to .content-with-mascots
+   left/right: 0 = panel edge. translateX ±82% pulls them
+   mostly outside with a slight overlap (ear/elbow/foot peek).
+   ----------------------------------------------------------- */
+@media (min-width: 900px) {
+  .content-with-mascots .mascot {
+    position: absolute !important;
+    display: block !important;
+    top: 50% !important;
+    height: calc(100vh - 180px) !important;
+    min-height: 450px !important;
+    max-height: 580px !important;
+    width: auto !important;
+    z-index: 30 !important;
+    pointer-events: none !important;
+  }
+
+  .content-with-mascots .mascot-left {
+    left: 0 !important;
+    transform: translateX(-82%) translateY(-50%) !important;
+  }
+
+  .content-with-mascots .mascot-right {
+    right: 0 !important;
+    transform: translateX(82%) translateY(-50%) !important;
+  }
+}
+
+@media (max-width: 899px) {
+  .content-with-mascots .mascot {
+    display: none !important;
+  }
+}
+
+/* -----------------------------------------------------------
+   FIX 2 — Hide the mobile rocket on landscape mobile
+   ----------------------------------------------------------- */
+@media (max-width: 950px) and (orientation: landscape) {
+  .mobile-rocket {
+    display: none !important;
+  }
+}
+
+/* -----------------------------------------------------------
+   FIX 3 — Mode buttons fit text on mobile landscape
+   ----------------------------------------------------------- */
+@media (max-width: 950px) and (orientation: landscape) {
+  .mode-btn {
+    font-size: 0.7rem !important;
+    padding: 4px 6px !important;
+    white-space: nowrap !important;
+    min-width: 0 !important;
+  }
+
+  .mode-toggle-container {
+    gap: 4px !important;
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1344,13 +1344,10 @@
     </header>
 
     <div class="main-wrapper">
-      <img src="boy-mascot.png" alt="Eli Mascot" class="mascot mascot-left" />
-      <img
-        src="girl-mascot.png"
-        alt="Roxy Mascot"
-        class="mascot mascot-right"
-      />
       <img src="rocket.png" alt="Mobile Rocket" class="mobile-rocket" />
+      <div class="content-with-mascots">
+        <img src="boy-mascot.png" alt="Eli Mascot" class="mascot mascot-left" />
+        <img src="girl-mascot.png" alt="Roxy Mascot" class="mascot mascot-right" />
       <div class="main-content">
         <div class="status-panel">
           <div>
@@ -1462,6 +1459,7 @@
             />
           </div>
         </div>
+      </div>
       </div>
 
       <div class="footer">


### PR DESCRIPTION
HTML (index.html):
- Reparent .mascot-left and .mascot-right images into a new <div class="content-with-mascots"> wrapper that also holds .main-content. Moved .mobile-rocket up to remain a direct child of .main-wrapper. Reformatted the two mascot <img> tags onto single lines. Added one new closing </div> after .main-content to close .content-with-mascots.
- Zero other HTML changes. All JS-referenced IDs intact: truth-mode, business-mode, sitemonkeys-mode, confidenceToggleWrapper, confidenceToggleBtn.

CSS (overhaul.css):
- .content-with-mascots positioned relative, 92% width, max 1400px, centered via margin: 0 auto — matches main-content width so the mascots anchor to the panel edges exactly.
- @media ≥900px: mascots positioned absolute within .content-with-mascots, top:50%, height calc(100vh - 180px), min 450 / max 580. left:0 + translateX(-82%) / right:0 + translateX(82%) for slight outside-the-panel peek.
- @media ≤899px: .content-with-mascots .mascot display:none.
- @media ≤950px landscape: .mobile-rocket display:none.
- @media ≤950px landscape: .mode-btn font-size 0.7rem, padding 4px 6px, nowrap, min-width 0. .mode-toggle-container gap 4px.

CSS-only. No JS touched.

https://claude.ai/code/session_017ji176hGykfVzFtAXwVPUj