### PR TITLE
Pass 15 mascot overlap 72% + landscape mobile tightening

### DIFF
--- a/public/css/overhaul.css
+++ b/public/css/overhaul.css
@@ -2684,3 +2684,71 @@ header {
     text-overflow: ellipsis !important;
   }
 }
+
+/* ============================================================
+   PASS 15 — Mascot overlap 72% + landscape show with smaller
+   sizing + tighter mode buttons
+   Appended after Pass 14. CSS-only; no JS/HTML changes.
+   ============================================================ */
+
+/* Desktop — increase overlap from 60% to 72% */
+@media (min-width: 900px) {
+  .content-with-mascots .mascot-left {
+    transform: translateX(-72%) translateY(-50%) !important;
+  }
+  .content-with-mascots .mascot-right {
+    transform: translateX(72%) translateY(-50%) !important;
+  }
+}
+
+/* Landscape mobile — show mascots small, hide rocket,
+   fix buttons. Using higher specificity to beat prior rules. */
+@media (max-width: 950px) and (orientation: landscape) {
+  .mobile-rocket {
+    display: none !important;
+    visibility: hidden !important;
+  }
+
+  .content-with-mascots .mascot {
+    display: block !important;
+    height: calc(100vh - 160px) !important;
+    min-height: 180px !important;
+    max-height: 240px !important;
+    width: auto !important;
+    position: absolute !important;
+    top: 50% !important;
+    z-index: 30 !important;
+    pointer-events: none !important;
+  }
+
+  .content-with-mascots .mascot-left {
+    left: 0 !important;
+    transform: translateX(-65%) translateY(-50%) !important;
+  }
+
+  .content-with-mascots .mascot-right {
+    right: 0 !important;
+    transform: translateX(65%) translateY(-50%) !important;
+  }
+
+  .mode-toggle-container {
+    width: 100% !important;
+    display: flex !important;
+    flex-direction: row !important;
+    gap: 3px !important;
+    padding: 2px 4px !important;
+    box-sizing: border-box !important;
+  }
+
+  .mode-btn {
+    flex: 1 1 0 !important;
+    min-width: 0 !important;
+    font-size: 0.6rem !important;
+    padding: 3px 2px !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    text-align: center !important;
+    box-sizing: border-box !important;
+  }
+}


### PR DESCRIPTION
- Desktop ≥900px: .content-with-mascots .mascot-left/-right transform translateX ±72% (increased from 60%)
- Landscape ≤950px:
  * .mobile-rocket display:none + visibility:hidden
  * .content-with-mascots .mascot shown at 180-240px height, absolute positioned with top:50%, z-index 30
  * mascot-left/-right at left/right 0 with translateX ±65%
  * .mode-toggle-container full width flex row with 3px gap, 2px 4px padding
  * .mode-btn flex 1 1 0, 0.6rem font, 3px 2px padding, ellipsis overflow, center aligned

All placed after Pass 14 counterparts. Later source order with !important wins the cascade.

CSS-only. No JS, HTML, or structural changes.

https://claude.ai/code/session_017ji176hGykfVzFtAXwVPUj