### PR TITLE
Pass 16 raise landscape breakpoint 950px -> 1100px

### DIFF
--- a/public/css/overhaul.css
+++ b/public/css/overhaul.css
@@ -2752,3 +2752,64 @@ header {
     box-sizing: border-box !important;
   }
 }
+
+/* ============================================================
+   PASS 16 — Raise landscape breakpoint from 950px to 1100px
+   Catches wider iPhones (iPhone 14/15/16 Pro Max etc.) in
+   landscape where viewport width is 932px-956px. The embedded
+   CSS landscape queries stop at 950px, so 951-1100px landscape
+   previously fell back to desktop layout. This block mirrors
+   the Pass 15 landscape rules at the wider 1100px breakpoint.
+   Appended after Pass 15. CSS-only; no JS/HTML changes.
+   ============================================================ */
+
+@media (max-width: 1100px) and (orientation: landscape) {
+
+  .mobile-rocket {
+    display: none !important;
+    visibility: hidden !important;
+  }
+
+  .content-with-mascots .mascot {
+    display: block !important;
+    height: calc(100vh - 160px) !important;
+    min-height: 180px !important;
+    max-height: 240px !important;
+    width: auto !important;
+    position: absolute !important;
+    top: 50% !important;
+    z-index: 30 !important;
+    pointer-events: none !important;
+  }
+
+  .content-with-mascots .mascot-left {
+    left: 0 !important;
+    transform: translateX(-65%) translateY(-50%) !important;
+  }
+
+  .content-with-mascots .mascot-right {
+    right: 0 !important;
+    transform: translateX(65%) translateY(-50%) !important;
+  }
+
+  .mode-toggle-container {
+    width: 100% !important;
+    display: flex !important;
+    flex-direction: row !important;
+    gap: 3px !important;
+    padding: 2px 4px !important;
+    box-sizing: border-box !important;
+  }
+
+  .mode-btn {
+    flex: 1 1 0 !important;
+    min-width: 0 !important;
+    font-size: 0.6rem !important;
+    padding: 3px 2px !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    text-align: center !important;
+    box-sizing: border-box !important;
+  }
+}


### PR DESCRIPTION
Mirrors the Pass 15 @media (max-width: 950px) landscape block at the wider 1100px breakpoint to catch larger iPhones in landscape (viewport widths ~932-956px on iPhone 14/15/16 Pro Max where the embedded 950px breakpoint missed them).

Rules applied (all inside @media (max-width: 1100px) and (orientation: landscape)):
- .mobile-rocket display:none + visibility:hidden
- .content-with-mascots .mascot shown at 180-240px height, absolute positioned
- .mascot-left/-right at left/right 0 with translateX ±65%
- .mode-toggle-container full-width flex row, gap 3px, padding 2px 4px
- .mode-btn flex 1 1 0, 0.6rem font, 3px 2px padding, ellipsis overflow, center aligned

Placed after all Pass 15 rules. Later source order with !important wins the cascade at equal specificity.

CSS-only. No JS, HTML, or structural changes.

https://claude.ai/code/session_017ji176hGykfVzFtAXwVPUj