### PR TITLE
Pass 19 landscape buttons tighter + mascots pushed to 78%

### DIFF
--- a/public/css/overhaul.css
+++ b/public/css/overhaul.css
@@ -2894,3 +2894,53 @@ header {
     box-sizing: border-box !important;
   }
 }
+
+/* LANDSCAPE MOBILE - buttons, mascots */
+@media (max-width: 1100px) and (orientation: landscape) {
+
+  .mode-toggle-container {
+    width: 100% !important;
+    display: flex !important;
+    flex-direction: row !important;
+    gap: 2px !important;
+    padding: 2px 2px !important;
+    box-sizing: border-box !important;
+  }
+
+  .mode-btn {
+    flex: 1 1 0 !important;
+    min-width: 0 !important;
+    width: 0 !important;
+    font-size: 0.52rem !important;
+    padding: 3px 1px !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    text-align: center !important;
+    box-sizing: border-box !important;
+    letter-spacing: 0 !important;
+  }
+
+  .content-with-mascots .mascot-left {
+    left: 0 !important;
+    transform: translateX(-78%) translateY(-50%) !important;
+  }
+
+  .content-with-mascots .mascot-right {
+    right: 0 !important;
+    transform: translateX(78%) translateY(-50%) !important;
+  }
+}
+
+/* DESKTOP - push mascots further outside */
+@media (min-width: 900px) {
+  .content-with-mascots .mascot-left {
+    left: 0 !important;
+    transform: translateX(-78%) translateY(-50%) !important;
+  }
+
+  .content-with-mascots .mascot-right {
+    right: 0 !important;
+    transform: translateX(78%) translateY(-50%) !important;
+  }
+}


### PR DESCRIPTION
Landscape (max-width: 1100px):
- .mode-toggle-container gap:2px, padding:2px 2px
- .mode-btn font-size:0.52rem, padding:3px 1px, width:0, letter-spacing:0
- .mascot-left/-right translateX ±78%

Desktop (min-width: 900px):
- .mascot-left/-right translateX ±78% (up from 72%)

All placed after Pass 18. Later source order wins. CSS-only. No JS, HTML, or structural changes.

https://claude.ai/code/session_017ji176hGykfVzFtAXwVPUj